### PR TITLE
tidy up python dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,8 @@ setup(
     include_package_data=True,
     install_requires=["sslyze>=4.0.0",
                       "dnspython>=2.0.0",
-                      "http-client>=0.1.21",
                       "urllib3~=1.22",
-                      "ipaddress>=1.0.22",
-                      "pathlib~=1.0.1",
-                      "bs4>=0.0.1",
+                      "beautifulsoup4",
                       "regex>=2020.5.14"],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This is a rebased version of PR#19

- bs4 is just a wrapper for beautifulsoup4
- http_client seems unused anywhere
- pathlib and ipaddress are python2 backports of python3 modules